### PR TITLE
Fixed LoadError on linux

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,6 @@ require_relative 'lib/image_generator'
 require_relative 'lib/emoji_scanner'
 
 require 'pathname'
-require 'Rmagick'
+require 'rmagick'
 require 'json'
 require 'slop'


### PR DESCRIPTION
`require': cannot load such file -- Rmagick (LoadError)

Mac OS X is case insensitive whereas linux is not
Also had this message:
W: `require 'RMagick'` is deprecated, please change to `require 'rmagick'`